### PR TITLE
Fixes #14, Fixes #15

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1,48 +1,66 @@
+using Assets.Scripts;
 using UnityEngine;
 
 public class GameManager : MonoBehaviour
 {
     private Vector2 _playerStartingPosition = new(0,0);
     private GameObject _playerObj;
+    private int _mapHeight;
+    private int _mapWidth;
+    private int _squareSize => _mapSize switch
+    {
+        MapSize.Small => 5,
+        MapSize.Medium => 7,
+        MapSize.Large => 9
+    };
 
+    [SerializeField] private MapSize _mapSize;
     [SerializeField] private GameObject _roomPrefab;
     [SerializeField] private GameObject _playerPrefab;
     [SerializeField] private GameObject _roomsManager;
     [SerializeField] private Camera _camera;
     [SerializeField] private Room[,] _rooms;
-    [SerializeField] private int _roomsHeight;
-    [SerializeField] private int _roomsWidth;
-    [SerializeField] private float _spacing;
+    [SerializeField] private float _roomSpacing;
 
     public Player Player => _playerObj.GetComponent<Player>();
+    public MapSize MapSize => _mapSize;
+
 
     void Start()
     {
+        _mapHeight = _squareSize;
+        _mapWidth = _squareSize;
+
         _playerObj = Instantiate(_playerPrefab, _playerStartingPosition, Quaternion.identity);
-        _rooms = new Room[_roomsHeight, _roomsWidth];
+        _rooms = new Room[_mapHeight, _mapWidth];
         Debug.Log("Board is building");
         BuildRooms();
         SpawnPlayer();
-        _camera.SetFocus(_rooms[2, 2].gameObject);
+
+        int centerX = _mapWidth / 2;
+        int centerY = _mapHeight / 2;
+        _camera.SetFocus(_rooms[centerX, centerY].gameObject);
     }
     public void BuildRooms()
     {
-        for (int i = 0; i < _roomsWidth; i++)
+        for (int i = 0; i < _mapWidth; i++)
         {
-            for (int j = 0; j < _roomsHeight; j++)
+            for (int j = 0; j < _mapHeight; j++)
             {
-                Vector2 position = new(i * _spacing, j * _spacing);
+                Vector2 position = new(i * _roomSpacing, j * _roomSpacing);
                 GameObject roomObj = Instantiate(_roomPrefab, position, Quaternion.identity, _roomsManager.transform);
                 Room room = roomObj.GetComponent<Room>();
+                room.SetLocation(new Location(i, j));
                 _rooms[i, j] = room;
-                Debug.Log($"New room placed at ({position})");
+                Debug.Log($"New room placed at ({room.Location.X}, {room.Location.Y})");
             }
         }
     }
 
     public void SpawnPlayer()
     {
-        Player.Move(_playerStartingPosition.x, _playerStartingPosition.y);
+        Location startLocation = new(_playerStartingPosition.x, _playerStartingPosition.y);
+        Player.SetLocation(startLocation);
     }
 }
 

--- a/Assets/Scripts/MapSize.cs
+++ b/Assets/Scripts/MapSize.cs
@@ -1,0 +1,4 @@
+﻿namespace Assets.Scripts
+{
+    public enum MapSize { Small, Medium, Large }
+}

--- a/Assets/Scripts/MapSize.cs.meta
+++ b/Assets/Scripts/MapSize.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 83649e8027732604183aa4d667bfa545

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -1,11 +1,10 @@
-using System;
 using UnityEngine;
 using Assets.Scripts;
 
 public class Player : MonoBehaviour
 { 
     public Location Location { get; private set; }
-    // Start is called once before the first execution of Update after the MonoBehaviour is created
+    
     void Start()
     {
         Debug.Log("Debug Log: Player has joined the game.");
@@ -18,5 +17,5 @@ public class Player : MonoBehaviour
         
     }
 
-    public void Move(float x, float y) => Location = new Location(x, y);
+    public void SetLocation(Location location) => Location = location;
 }

--- a/Assets/Scripts/Room.cs
+++ b/Assets/Scripts/Room.cs
@@ -1,5 +1,15 @@
 using UnityEngine;
+using Assets.Scripts;
+
 
 public class Room : MonoBehaviour
 {
-}
+    public Location Location { get; private set; }
+
+    public Room(Location location)
+    {
+        Location = location;
+    }
+
+    public void SetLocation(Location location) => Location = location;
+} 


### PR DESCRIPTION
Refactor Location and Mapsize Logic
- Player method for SetLocation() renamed from Move() and also takes a Location object rather than 2 ints

- Room class now stores Location data and mirrors logic of Player

- Map size is now a dropdown enum and autocalculated

- Camera is now anchored to a calculated center-point of the map.